### PR TITLE
Implement TestThemeProvider, use in ProgressBarV2.test.js

### DIFF
--- a/assets/src/__tests__/components/ProgressBarV2.test.js
+++ b/assets/src/__tests__/components/ProgressBarV2.test.js
@@ -4,33 +4,37 @@ import React from 'react'
 import ProgressBarV2 from '../../components/ProgressBarV2'
 import renderer from 'react-test-renderer'
 
+import TestThemeProvider from '../../components/TestThemeProvider'
+
 it('renders correctly', () => {
   const tree = renderer
     .create(
-      <ProgressBarV2
-        submitted=''
-        score={85}
-        outOf={100}
-        percentWidth={90}
-        lines={[{
-          label: 'Current',
-          value: 80,
-          color: 'steelblue',
-          labelPlacement: 'down'
-        },
-        {
-          label: 'Goal',
-          value: 40,
-          color: 'green',
-          labelPlacement: 'up'
-        },
-        {
-          label: 'Max Possible',
-          value: 23,
-          color: 'grey',
-          labelPlacement: 'downLower'
-        }]}
-      />
+      <TestThemeProvider>
+        <ProgressBarV2
+          submitted=''
+          score={85}
+          outOf={100}
+          percentWidth={90}
+          lines={[{
+            label: 'Current',
+            value: 80,
+            color: 'steelblue',
+            labelPlacement: 'down'
+          },
+          {
+            label: 'Goal',
+            value: 40,
+            color: 'green',
+            labelPlacement: 'up'
+          },
+          {
+            label: 'Max Possible',
+            value: 23,
+            color: 'grey',
+            labelPlacement: 'downLower'
+          }]}
+        />
+      </TestThemeProvider>
     ).toJSON()
 
   expect(tree).toMatchSnapshot()

--- a/assets/src/components/ProgressBarV2.js
+++ b/assets/src/components/ProgressBarV2.js
@@ -15,7 +15,7 @@ const styles = theme => ({
 
   outOfBar: {
     // for Jest test the negative palette attributes is not available so adding the condition
-    backgroundColor: theme.palette.negative ? theme.palette.negative.main : '#B5B5B5'
+    backgroundColor: theme.palette.negative.main
   }
 })
 

--- a/assets/src/components/TestThemeProvider.js
+++ b/assets/src/components/TestThemeProvider.js
@@ -1,0 +1,10 @@
+import * as React from 'react'
+import { ThemeProvider } from '@material-ui/core/styles'
+
+import { siteTheme } from '../globals'
+
+function TestThemeProvider ({ children }) {
+  return <ThemeProvider theme={siteTheme}>{children}</ThemeProvider>
+}
+
+export default TestThemeProvider


### PR DESCRIPTION
I think we can do something like this so you don't have to hardcode hex values. It may need a little more research, but the tests pass.

Links:
- https://stackoverflow.com/questions/58627085/jest-manual-mock-for-themeprovider
- https://material-ui.com/guides/testing/