### PR TITLE
Refactor minimum goal, progress bar layout

### DIFF
--- a/assets/src/__tests__/components/__snapshots__/AssignmentGradeBoxes.test.js.snap
+++ b/assets/src/__tests__/components/__snapshots__/AssignmentGradeBoxes.test.js.snap
@@ -3,20 +3,9 @@
 exports[`renders correctly 1`] = `
 <div
   className="MuiGrid-root MuiGrid-item"
-  style={
-    Object {
-      "display": "inline-block",
-    }
-  }
 >
   <h6
-    className="MuiTypography-root MuiTypography-h6"
-    style={
-      Object {
-        "display": "inline-block",
-        "marginRight": "10px",
-      }
-    }
+    className="MuiTypography-root MuiTypography-h6 MuiTypography-gutterBottom"
   >
     My Minimum Goal
   </h6>

--- a/assets/src/__tests__/components/__snapshots__/ProgressBarV2.test.js.snap
+++ b/assets/src/__tests__/components/__snapshots__/ProgressBarV2.test.js.snap
@@ -5,9 +5,8 @@ exports[`renders correctly 1`] = `
   className="ProgressBarV2-outOfBar-3"
   style={
     Object {
-      "float": "left",
       "height": "10px",
-      "margin": "0px",
+      "margin": undefined,
       "position": "relative",
       "width": "90%",
     }

--- a/assets/src/components/AssignmentGoalInput.js
+++ b/assets/src/components/AssignmentGoalInput.js
@@ -39,8 +39,8 @@ function AssignmentGoalInput (props) {
   }, [goalGrade])
 
   return (
-    <Grid item style={{ display: 'inline-block' }}>
-      <Typography style={{ display: 'inline-block', marginRight: '10px' }} variant='h6'>My Minimum Goal</Typography>
+    <Grid item>
+      <Typography variant='h6' gutterBottom>My Minimum Goal</Typography>
       <StyledTextField
         error={goalGradeInternal > 100 || mathWarning || goalGradeInternal > maxPossibleGrade}
         id='standard-number'

--- a/assets/src/components/ProgressBarV2.js
+++ b/assets/src/components/ProgressBarV2.js
@@ -26,6 +26,7 @@ function ProgressBarV2 (props) {
     submitted,
     percentWidth,
     height = 10,
+    margin,
     lines = [],
     description
   } = props
@@ -57,7 +58,7 @@ function ProgressBarV2 (props) {
             width: `${percentWidth}%`,
             height: `${height}px`,
             position: 'relative',
-            margin: 'auto'
+            margin: margin
           }}
         >
           {

--- a/assets/src/components/ProgressBarV2.js
+++ b/assets/src/components/ProgressBarV2.js
@@ -26,9 +26,7 @@ function ProgressBarV2 (props) {
     submitted,
     percentWidth,
     height = 10,
-    margin = 0,
     lines = [],
-    floatTo = 'left',
     description
   } = props
 
@@ -59,8 +57,7 @@ function ProgressBarV2 (props) {
             width: `${percentWidth}%`,
             height: `${height}px`,
             position: 'relative',
-            margin: `${margin}px`,
-            float: floatTo
+            margin: 'auto'
           }}
         >
           {

--- a/assets/src/components/TestThemeProvider.js
+++ b/assets/src/components/TestThemeProvider.js
@@ -1,0 +1,10 @@
+import * as React from 'react'
+import { ThemeProvider } from '@material-ui/core/styles'
+
+import { siteTheme } from '../globals'
+
+function TestThemeProvider ({ children }) {
+  return <ThemeProvider theme={siteTheme}>{children}</ThemeProvider>
+}
+
+export default TestThemeProvider

--- a/assets/src/containers/AssignmentPlanningV2.js
+++ b/assets/src/containers/AssignmentPlanningV2.js
@@ -55,7 +55,11 @@ const styles = theme => ({
   },
   legendItem: {
     display: 'inline-block',
-    marginRight: '10px'
+    marginRight: '14px'
+  },
+  legendItemLabel: {
+    display: 'inline',
+    marginLeft: '6px'
   },
   graded: {
     background: theme.palette.secondary.main
@@ -221,15 +225,15 @@ function AssignmentPlanningV2 (props) {
                           <Typography variant='h6' gutterBottom>Assignment Status</Typography>
                           <div className={classes.legendItem}>
                             <div className={classes.graded + ' ' + classes.assignStatus} />
-                            <Typography display='inline' style={{ padding: '6px' }}>{assignmentStatus.GRADED}</Typography>
+                            <Typography className={classes.legendItemLabel}>{assignmentStatus.GRADED}</Typography>
                           </div>
                           <div className={classes.legendItem}>
                             <div className={classes.ungraded + ' ' + classes.assignStatus} />
-                            <Typography display='inline' style={{ padding: '6px' }}>{assignmentStatus.SUBMITTED}</Typography>
+                            <Typography className={classes.legendItemLabel}>{assignmentStatus.SUBMITTED}</Typography>
                           </div>
                           <div className={classes.legendItem}>
                             <div className={classes.unsubmitted + ' ' + classes.assignStatus} />
-                            <Typography display='inline' style={{ padding: '6px' }}>{assignmentStatus.UNSUBMITTED}</Typography>
+                            <Typography className={classes.legendItemLabel}>{assignmentStatus.UNSUBMITTED}</Typography>
                           </div>
                         </Grid>
                       </Grid>

--- a/assets/src/containers/AssignmentPlanningV2.js
+++ b/assets/src/containers/AssignmentPlanningV2.js
@@ -46,12 +46,16 @@ const styles = theme => ({
     margin: '30px'
   },
   mainProgressBar: {
-    marginBottom: '50px'
+    marginBottom: '2.5rem'
   },
   assignStatus: {
     width: '10px',
     height: '10px',
     display: 'inline-block'
+  },
+  legendItem: {
+    display: 'inline-block',
+    marginRight: '10px'
   },
   graded: {
     background: theme.palette.secondary.main
@@ -163,7 +167,7 @@ function AssignmentPlanningV2 (props) {
                   : (
                     <div>
                       <Grid container alignContent='center' className={classes.section}>
-                        <Grid item xs={4}>
+                        <Grid item lg={4} md={5} xs={12}>
                           <AssignmentGoalInput
                             currentGrade={currentGrade}
                             goalGrade={goalGrade}
@@ -179,10 +183,8 @@ function AssignmentPlanningV2 (props) {
                             mathWarning={showMathWarning}
                           />
                         </Grid>
-                        <Grid item xs={8} style={{ display: 'inline-block' }}>
-                          <Typography style={{ display: 'inline-block', paddingLeft: '30px' }} variant='h6'>Grade
-                            Progress
-                          </Typography>
+                        <Grid item lg={8} md={7} xs={12} className={classes.mainProgressBar}>
+                          <Typography variant='h6' gutterBottom>Grade Progress</Typography>
                           <ProgressBarV2
                             score={currentGrade}
                             lines={[
@@ -206,25 +208,29 @@ function AssignmentPlanningV2 (props) {
                               }
                             ]}
                             outOf={100}
-                            percentWidth={80}
+                            percentWidth={100}
                             height={50}
-                            floatTo='right'
                           />
                         </Grid>
                       </Grid>
-                      <div style={{ margin: '20px' }} />
                       <Grid container>
                         <Grid item xs={6} md={8}>
                           <Typography variant='h6' gutterBottom>Assignments by Due Date</Typography>
                         </Grid>
-                        <Grid item xs={6} md={4}>
-                          <Typography variant='h6'>Assignment Status</Typography>
-                          <div className={classes.graded + ' ' + classes.assignStatus} />
-                          <Typography style={{ display: 'inline', padding: '4px', marginRight: '2px' }}> {assignmentStatus.GRADED}</Typography>
-                          <div className={classes.ungraded + ' ' + classes.assignStatus} />
-                          <Typography style={{ display: 'inline', padding: '4px', marginRight: '2px' }}> {assignmentStatus.SUBMITTED}</Typography>
-                          <div className={classes.unsubmitted + ' ' + classes.assignStatus} />
-                          <Typography style={{ display: 'inline', padding: '4px' }}> {assignmentStatus.UNSUBMITTED}</Typography>
+                        <Grid item xs={6} md={4} style={{ marginBottom: '1rem' }}>
+                          <Typography variant='h6' gutterBottom>Assignment Status</Typography>
+                          <div className={classes.legendItem}>
+                            <div className={classes.graded + ' ' + classes.assignStatus} />
+                            <Typography display='inline' style={{ padding: '6px' }}>{assignmentStatus.GRADED}</Typography>
+                          </div>
+                          <div className={classes.legendItem}>
+                            <div className={classes.ungraded + ' ' + classes.assignStatus} />
+                            <Typography display='inline' style={{ padding: '6px' }}>{assignmentStatus.SUBMITTED}</Typography>
+                          </div>
+                          <div className={classes.legendItem}>
+                            <div className={classes.unsubmitted + ' ' + classes.assignStatus} />
+                            <Typography display='inline' style={{ padding: '6px' }}>{assignmentStatus.UNSUBMITTED}</Typography>
+                          </div>
                         </Grid>
                       </Grid>
                       <AssignmentTable


### PR DESCRIPTION
@pushyamig, I was able to adjust the alignment of the other progress bars by removing the `margin: 'auto'` default. I also elected to keep the `margin` prop in case it's needed in the future (it's not being used now, I don't think).