### PR TITLE
Have all GQL queries behind Login

### DIFF
--- a/dashboard/graphql/view.py
+++ b/dashboard/graphql/view.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from graphene_django.views import GraphQLView
 import json
 from dashboard.common.db_util import canvas_id_to_incremented_id
@@ -17,7 +18,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class DashboardGraphQLView(GraphQLView):
+class DashboardGraphQLView(LoginRequiredMixin, GraphQLView):
     def get_context(self, request):
         loaders = {
             'assignment_weight_consideration_by_course_id_loader': AssignmentWeightConsiderationByCourseIdLoader(

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,39 @@
+version: '3.7'
+
+services:
+  mysql:
+    image: mysql:8.0
+    restart: on-failure
+    environment:
+      - MYSQL_HOST=${MYSQL_HOST}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_PORT=${MYSQL_PORT}
+    entrypoint: ['docker-entrypoint.sh', '--default-authentication-plugin=mysql_native_password']
+    ports:
+      - "5306:3306"
+    volumes:
+      - ./.data/mysql:/var/lib/mysql
+      - ./mysql:/docker-entrypoint-initdb.d/:ro
+    container_name: student_dashboard_mysql
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        TZ: ${TZ}
+    command: bash -c "/code/start.sh"
+    volumes:
+      - ${HOME}/mylasecrets:/secrets
+    ports:
+      - "5001:5000"
+    depends_on:
+      - mysql
+    env_file:
+      - .env
+    environment:
+      - DJANGO_DEBUG=False
+      - DEBUG=False
+    container_name: student_dashboard


### PR DESCRIPTION
In env.hjson: 
STUDENT_DASHBOARD_LTI: true
"ENABLE_BACKEND_LOGIN": false
"DJANGO_DEBUG": false, (You might see some error static main-deddsd.js is missing, running in the prod mode is better)

This fix basically redirect to Django Login page, since we disabled backend login, we will see page not found error

https://replace-your-URL/graphql?query=%7B__schema%7Btypes%7Bname,fields%7Bname%7D%7D%7D%7D

https://33f6-141-213-175-192.ngrok-free.app/graphql: The browser Query making is enabled by default locally but not in Prod.

Make simple query as from the query window, this should fetch results
```
{
       course(courseId: "562259", canvasId: "562259") {
      courses:
        id
        termId
      }
      
     }
```